### PR TITLE
Dockerfile: add API_VERSION env var propagation to args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ COPY --from=glide /go/src/github.com/jirwin/burrow_exporter/burrow-exporter .
 ENV BURROW_ADDR http://localhost:8000
 ENV METRICS_ADDR 0.0.0.0:8080
 ENV INTERVAL 30
-CMD ./burrow-exporter --burrow-addr $BURROW_ADDR --metrics-addr $METRICS_ADDR --interval $INTERVAL
+CMD ./burrow-exporter --burrow-addr $BURROW_ADDR --metrics-addr $METRICS_ADDR --interval $INTERVAL --api-version $API_VERSION


### PR DESCRIPTION
getting below error while using latest 
```
time="2018-06-04T13:30:19Z" level=info msg="Scraping burrow..." timestamp=1528119019789526462
time="2018-06-04T13:30:19Z" level=error msg="error retrieving clusters" err="invalid request type"
time="2018-06-04T13:30:19Z" level=error msg="error listing clusters. Continuing." err="invalid request type" 
```
currently using workaround:
```
        image: solsson/burrow-exporter@sha256:379199629e22a25e140a391f0a52bb5e222e6a639ce2314d8a995d0eeecb6c3f
        command:
          - /bin/sh
          - -c
          - ./burrow-exporter --burrow-addr $BURROW_ADDR --metrics-addr $METRICS_ADDR --interval $INTERVAL --api-version $API_VERSION
```

as an additional change - maybe switching default to `v3` [here](https://github.com/solsson/burrow_exporter/blob/master/burrow-exporter.go#L39) would make sense